### PR TITLE
Add Daimler truck dealership competition simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Daimler Dealership Competition Simulation
+
+This repository contains a simple agent-based simulation focused on how a Daimler truck dealership competes with rival dealerships from Volvo and PACCAR. The model mixes manufacturer attributes, dealership capabilities, and market behavior to estimate monthly sales and overall market share.
+
+## Features
+
+- Manufacturer and dealership data models capturing pricing, technology, service quality, and local relationships.
+- Market dynamics including baseline demand, economic volatility, and customer preferences.
+- Preconfigured scenario for Daimler versus Volvo and PACCAR competitors with a command line interface.
+
+## Usage
+
+Run the simulation for 12 months with a deterministic seed:
+
+```bash
+python -m simulation.main --months 12 --seed 42
+```
+
+Optionally, write the summary to a JSON file:
+
+```bash
+python -m simulation.main --months 18 --seed 7 --output results.json
+```
+
+The command prints a JSON summary of total sales and market share for each dealership.
+
+## Extending the Model
+
+- Adjust manufacturer and dealership parameters in `simulation/scenario.py` to explore alternate strategies.
+- Modify weights and demand assumptions in `simulation/market.py` for different economic conditions.
+- Swap out the preconfigured scenario by importing the package in your own scripts.
+

--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -1,0 +1,14 @@
+"""Simulation package for modeling truck dealership competition."""
+
+from .entities import TruckModel, Dealership, Manufacturer
+from .market import Market, MarketParameters
+from .scenario import DaimlerDealershipScenario
+
+__all__ = [
+    "TruckModel",
+    "Dealership",
+    "Manufacturer",
+    "Market",
+    "MarketParameters",
+    "DaimlerDealershipScenario",
+]

--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -1,0 +1,89 @@
+"""Entity definitions for the truck dealership competition simulation."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class TruckModel:
+    """Represents a truck model offered by a manufacturer."""
+
+    name: str
+    segment: str
+    base_price: float
+    fuel_efficiency: float
+    tech_rating: float
+    durability: float
+
+    def desirability(self, weightings: Dict[str, float]) -> float:
+        """Compute a desirability score using weighted attributes."""
+        return (
+            weightings.get("price", 0.0) * (1 / self.base_price)
+            + weightings.get("fuel_efficiency", 0.0) * self.fuel_efficiency
+            + weightings.get("tech_rating", 0.0) * self.tech_rating
+            + weightings.get("durability", 0.0) * self.durability
+        )
+
+
+@dataclass
+class Manufacturer:
+    """Represents a truck manufacturer."""
+
+    name: str
+    reputation: float
+    innovation: float
+    service_network: float
+    marketing_power: float
+    models: List[TruckModel] = field(default_factory=list)
+
+    def overall_strength(self) -> float:
+        """Weighted strength used for baseline demand splitting."""
+        return (
+            self.reputation * 0.3
+            + self.innovation * 0.25
+            + self.service_network * 0.25
+            + self.marketing_power * 0.2
+        )
+
+
+@dataclass
+class Dealership:
+    """Represents a dealership competing in the market."""
+
+    name: str
+    manufacturer: Manufacturer
+    local_relationships: float
+    salesforce: float
+    inventory: Dict[str, int]
+    price_adjustment: float = 0.0
+    marketing_spend: float = 0.0
+    service_quality: float = 0.5
+    loyalty_program: bool = False
+
+    def effective_price(self, model: TruckModel) -> float:
+        """Compute effective price after adjustments."""
+        return model.base_price * (1 + self.price_adjustment)
+
+    def sales_capacity(self) -> float:
+        """Simplified measure of how many trucks the dealership can sell."""
+        return self.salesforce * (1 + self.marketing_spend)
+
+    def customer_experience(self) -> float:
+        """Score capturing overall dealership experience."""
+        loyalty_bonus = 0.1 if self.loyalty_program else 0.0
+        return self.local_relationships * 0.4 + self.service_quality * 0.4 + loyalty_bonus
+
+    def select_model_for_sale(self, segment: str) -> TruckModel | None:
+        """Pick the most desirable model in stock for a given segment."""
+        candidates = [m for m in self.manufacturer.models if m.segment == segment]
+        candidates = [m for m in candidates if self.inventory.get(m.name, 0) > 0]
+        if not candidates:
+            return None
+        return max(candidates, key=lambda m: m.tech_rating + m.durability)
+
+    def record_sale(self, model_name: str) -> None:
+        """Reduce inventory when a sale is made."""
+        if model_name in self.inventory:
+            self.inventory[model_name] -= 1
+

--- a/simulation/main.py
+++ b/simulation/main.py
@@ -1,0 +1,39 @@
+"""Command line interface for running the Daimler dealership simulation."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .scenario import DaimlerDealershipScenario
+
+
+def run_simulation(months: int, seed: int | None, output: Path | None) -> dict[str, Any]:
+    scenario = DaimlerDealershipScenario(months=months, seed=seed)
+    result = scenario.run()
+    summary = result.summary()
+    if output:
+        output.write_text(json.dumps(summary, indent=2))
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate Daimler truck dealership competition")
+    parser.add_argument("--months", type=int, default=12, help="Number of months to simulate")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed for reproducibility")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the summary JSON",
+    )
+    args = parser.parse_args()
+
+    summary = run_simulation(months=args.months, seed=args.seed, output=args.output)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/simulation/market.py
+++ b/simulation/market.py
@@ -1,0 +1,103 @@
+"""Market simulation logic for competing truck dealerships."""
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+from .entities import Dealership, Manufacturer, TruckModel
+
+
+@dataclass
+class MarketParameters:
+    """Parameters controlling market behavior."""
+
+    base_demand: int = 120
+    economic_volatility: float = 0.15
+    fleet_growth_rate: float = 0.02
+    price_sensitivity: float = 0.4
+    experience_weight: float = 0.3
+    technology_weight: float = 0.2
+    fuel_weight: float = 0.1
+    durability_weight: float = 0.2
+    reputation_weight: float = 0.2
+
+
+class Market:
+    """Simulates demand allocation between dealerships."""
+
+    def __init__(self, parameters: MarketParameters | None = None, seed: int | None = None) -> None:
+        self.parameters = parameters or MarketParameters()
+        self.random = random.Random(seed)
+        self.history: List[Dict[str, float]] = []
+
+    def _effective_demand(self, month: int) -> float:
+        seasonal = 1 + 0.1 * math.sin(month * math.pi / 6)
+        economic_noise = self.random.uniform(-self.parameters.economic_volatility, self.parameters.economic_volatility)
+        trend = (1 + self.parameters.fleet_growth_rate) ** month
+        return max(0.0, self.parameters.base_demand * seasonal * (1 + economic_noise) * trend)
+
+    def _baseline_share(self, dealers: Iterable[Dealership]) -> Dict[str, float]:
+        strengths = {d.name: d.manufacturer.overall_strength() for d in dealers}
+        total = sum(strengths.values()) or 1.0
+        return {name: strength / total for name, strength in strengths.items()}
+
+    def _segment_preferences(self, model: TruckModel) -> float:
+        weights = {
+            "price": self.parameters.price_sensitivity,
+            "fuel_efficiency": self.parameters.fuel_weight,
+            "tech_rating": self.parameters.technology_weight,
+            "durability": self.parameters.durability_weight,
+        }
+        return model.desirability(weights)
+
+    def _dealer_competitiveness(self, dealer: Dealership, model: TruckModel) -> float:
+        price_factor = 1 / dealer.effective_price(model)
+        experience_factor = dealer.customer_experience() * self.parameters.experience_weight
+        capacity_factor = dealer.sales_capacity() ** 0.5
+        reputation_factor = dealer.manufacturer.reputation * self.parameters.reputation_weight
+        product_factor = self._segment_preferences(model)
+        return price_factor + experience_factor + capacity_factor + reputation_factor + product_factor
+
+    def simulate_month(self, month: int, dealers: List[Dealership]) -> Dict[str, float]:
+        demand = self._effective_demand(month)
+        baseline = self._baseline_share(dealers)
+        allocations: Dict[str, float] = {d.name: 0.0 for d in dealers}
+        product_choices: Dict[Tuple[str, str], int] = {}
+
+        for dealer in dealers:
+            baseline_demand = demand * baseline[dealer.name]
+            available_segments = {model.segment for model in dealer.manufacturer.models}
+            for segment in available_segments:
+                model = dealer.select_model_for_sale(segment)
+                if model is None:
+                    continue
+                competitiveness = self._dealer_competitiveness(dealer, model)
+                product_choices[(dealer.name, model.name)] = competitiveness
+
+            competitiveness_total = sum(
+                competitiveness
+                for (dealer_name, _), competitiveness in product_choices.items()
+                if dealer_name == dealer.name
+            )
+            if competitiveness_total == 0:
+                continue
+            for (dealer_name, model_name), competitiveness in list(product_choices.items()):
+                if dealer_name != dealer.name:
+                    continue
+                share = competitiveness / competitiveness_total
+                sales = baseline_demand * share
+                dealer.record_sale(model_name)
+                allocations[dealer.name] += sales
+
+        self.history.append(allocations)
+        return allocations
+
+    def simulate(self, months: int, dealers: List[Dealership]) -> List[Dict[str, float]]:
+        """Run the simulation across multiple months."""
+        results = []
+        for month in range(months):
+            results.append(self.simulate_month(month, dealers))
+        return results
+

--- a/simulation/scenario.py
+++ b/simulation/scenario.py
@@ -1,0 +1,121 @@
+"""Preconfigured scenario modelling Daimler vs competitors."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .entities import Dealership, Manufacturer, TruckModel
+from .market import Market, MarketParameters
+
+
+@dataclass
+class SimulationResult:
+    months: int
+    sales_history: List[dict]
+
+    def summary(self) -> dict:
+        aggregated: dict[str, float] = {}
+        for month in self.sales_history:
+            for dealer, sales in month.items():
+                aggregated[dealer] = aggregated.get(dealer, 0.0) + sales
+        total = sum(aggregated.values()) or 1.0
+        share = {dealer: sales / total for dealer, sales in aggregated.items()}
+        return {"total_sales": aggregated, "market_share": share}
+
+
+class DaimlerDealershipScenario:
+    """Builds a simulation focused on Daimler competing with other OEMs."""
+
+    def __init__(self, months: int = 12, seed: int | None = None, parameters: MarketParameters | None = None) -> None:
+        self.months = months
+        self.seed = seed
+        self.parameters = parameters or MarketParameters()
+
+    def _build_manufacturers(self) -> List[Manufacturer]:
+        daimler = Manufacturer(
+            name="Daimler Trucks",
+            reputation=0.82,
+            innovation=0.8,
+            service_network=0.85,
+            marketing_power=0.75,
+            models=[
+                TruckModel("Actros", "long-haul", 135000, 0.78, 0.82, 0.88),
+                TruckModel("Atego", "distribution", 95000, 0.82, 0.75, 0.83),
+                TruckModel("eActros", "electric", 220000, 0.95, 0.9, 0.8),
+            ],
+        )
+
+        volvo = Manufacturer(
+            name="Volvo Trucks",
+            reputation=0.79,
+            innovation=0.77,
+            service_network=0.8,
+            marketing_power=0.7,
+            models=[
+                TruckModel("FH16", "long-haul", 138000, 0.76, 0.79, 0.86),
+                TruckModel("FM", "distribution", 97000, 0.8, 0.76, 0.84),
+                TruckModel("FE Electric", "electric", 215000, 0.92, 0.85, 0.78),
+            ],
+        )
+
+        paccar = Manufacturer(
+            name="PACCAR",
+            reputation=0.75,
+            innovation=0.72,
+            service_network=0.78,
+            marketing_power=0.68,
+            models=[
+                TruckModel("Kenworth T680", "long-haul", 133000, 0.74, 0.74, 0.82),
+                TruckModel("Peterbilt 579", "distribution", 96000, 0.78, 0.73, 0.81),
+                TruckModel("Peterbilt 579EV", "electric", 210000, 0.9, 0.82, 0.77),
+            ],
+        )
+
+        return [daimler, volvo, paccar]
+
+    def _build_dealerships(self, manufacturers: List[Manufacturer]) -> List[Dealership]:
+        daimler_dealer = Dealership(
+            name="StarLine Daimler",
+            manufacturer=manufacturers[0],
+            local_relationships=0.88,
+            salesforce=0.83,
+            inventory={model.name: 30 for model in manufacturers[0].models},
+            price_adjustment=-0.03,
+            marketing_spend=0.12,
+            service_quality=0.87,
+            loyalty_program=True,
+        )
+
+        volvo_dealer = Dealership(
+            name="Northway Volvo",
+            manufacturer=manufacturers[1],
+            local_relationships=0.8,
+            salesforce=0.78,
+            inventory={model.name: 28 for model in manufacturers[1].models},
+            price_adjustment=-0.015,
+            marketing_spend=0.1,
+            service_quality=0.82,
+            loyalty_program=True,
+        )
+
+        paccar_dealer = Dealership(
+            name="Frontier PACCAR",
+            manufacturer=manufacturers[2],
+            local_relationships=0.76,
+            salesforce=0.75,
+            inventory={model.name: 26 for model in manufacturers[2].models},
+            price_adjustment=-0.01,
+            marketing_spend=0.08,
+            service_quality=0.8,
+            loyalty_program=False,
+        )
+
+        return [daimler_dealer, volvo_dealer, paccar_dealer]
+
+    def run(self) -> SimulationResult:
+        manufacturers = self._build_manufacturers()
+        dealerships = self._build_dealerships(manufacturers)
+        market = Market(self.parameters, seed=self.seed)
+        sales_history = market.simulate(self.months, dealerships)
+        return SimulationResult(months=self.months, sales_history=sales_history)
+


### PR DESCRIPTION
## Summary
- add simulation package modeling Daimler, Volvo, and PACCAR dealerships competing for truck sales
- implement market dynamics, preconfigured scenario, and CLI entry point to run the simulation
- document usage and configuration options in a new README

## Testing
- python -m simulation.main --months 6 --seed 42

------
https://chatgpt.com/codex/tasks/task_e_68e434be6cec8324afa58ae8205c5f5e